### PR TITLE
disabled input too when readOnly is true

### DIFF
--- a/src/vue3-tags-input.vue
+++ b/src/vue3-tags-input.vue
@@ -26,7 +26,8 @@
           @blur="handleInputBlur"
           @focus="handleInputFocus"
           @input="makeItNormal"
-          class="v3ti-new-tag"/>
+          class="v3ti-new-tag"
+          :disabled="readOnly"/>
     </div>
     <section v-if="select"
              class="v3ti-context-menu"


### PR DESCRIPTION
Hello bro. My name is Jorge Bou-saad, I`m from Venezuela. I make this change because I think is better when the input is disabled when the props readOnly is true. This is beause if you don`t disabled the input, users can write and delete tags. In my project that is a bug. If you make true readOnly, you cannot edit the input.

try it and give me feedback. It`s a pleasure to mee colaborate in this beautifull component. 

Thanks for reading

Jorge.